### PR TITLE
Feature/#68 메일 인증된 유저에 값 추가

### DIFF
--- a/backend/src/main/java/com/hjjang/backend/domain/mail/service/MailService.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/mail/service/MailService.java
@@ -1,25 +1,36 @@
 package com.hjjang.backend.domain.mail.service;
 
-import com.hjjang.backend.domain.mail.dto.Mail;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
 import com.hjjang.backend.domain.mail.domain.MailMessage;
 import com.hjjang.backend.domain.mail.domain.MailRegex;
+import com.hjjang.backend.domain.mail.dto.Mail;
 import com.hjjang.backend.domain.mail.dto.MailRequest;
 import com.hjjang.backend.domain.mail.dto.MailResponse;
 import com.hjjang.backend.domain.mail.exception.InvalidMailException;
 import com.hjjang.backend.domain.mail.exception.UnauthorizedException;
-import java.util.List;
-import java.util.regex.Pattern;
+import com.hjjang.backend.domain.university.entity.University;
+import com.hjjang.backend.domain.university.service.UniversityService;
+import com.hjjang.backend.domain.user.entity.User;
+import com.hjjang.backend.domain.user.repository.UserRepository;
+import com.hjjang.backend.global.util.UserUtil;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MailService {
 
+	private final UniversityService universityService;
+	private final UserRepository userRepository;
 	private final JavaMailSender javaMailSender;
 	private final Mail mail = new Mail();
+	private final UserUtil userUtil;
 
 	public MailResponse sendMail(String mailAddress) {
 		checkPossibleMail(mailAddress);
@@ -32,6 +43,10 @@ public class MailService {
 	public MailResponse checkCode(MailRequest mailRequest) {
 		checkRequest(mailRequest, mail);
 		mail.setIsAuth(true);
+		University university = universityService.findUniversityByName(mail.getUniversity());
+		User user = userUtil.getLoginUserByToken();
+		user.setEmailAndUniversity(mail.getAddress(), university);
+		userRepository.save(user);
 		return new MailResponse(mail);
 	}
 

--- a/backend/src/main/java/com/hjjang/backend/domain/post/domain/entity/Post.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/post/domain/entity/Post.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import com.hjjang.backend.domain.post.dto.PostRequestDto;
 import com.hjjang.backend.domain.university.entity.University;
+import com.hjjang.backend.domain.user.entity.User;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,9 +40,9 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // @ManyToOne
-    // @JoinColumn(name = "user_id")
-    // private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university_id", nullable = false)

--- a/backend/src/main/java/com/hjjang/backend/domain/university/repository/UniversityRepository.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/university/repository/UniversityRepository.java
@@ -10,4 +10,6 @@ import com.hjjang.backend.domain.university.entity.University;
 @Repository
 public interface UniversityRepository extends JpaRepository<University, Long> {
 	Optional<University> findByName(String name);
+
+	Boolean existsByName(String name);
 }

--- a/backend/src/main/java/com/hjjang/backend/domain/university/repository/UniversityRepository.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/university/repository/UniversityRepository.java
@@ -1,5 +1,7 @@
 package com.hjjang.backend.domain.university.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.hjjang.backend.domain.university.entity.University;
 
 @Repository
 public interface UniversityRepository extends JpaRepository<University, Long> {
+	Optional<University> findByName(String name);
 }

--- a/backend/src/main/java/com/hjjang/backend/domain/university/service/UniversityService.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/university/service/UniversityService.java
@@ -1,0 +1,18 @@
+package com.hjjang.backend.domain.university.service;
+
+import org.springframework.stereotype.Service;
+
+import com.hjjang.backend.domain.university.entity.University;
+import com.hjjang.backend.domain.university.repository.UniversityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UniversityService {
+	private final UniversityRepository universityRepository;
+
+	public University findUniversityByName(String name) {
+		return universityRepository.findByName(name).orElseThrow(RuntimeException::new);
+	}
+}

--- a/backend/src/main/java/com/hjjang/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/hjjang/backend/domain/user/entity/User.java
@@ -82,4 +82,10 @@ public class User extends BaseTimeEntity {
         this.isEmailVerification = isEmailVerification;
         this.isBlocked = isBlocked;
     }
+
+    @Builder
+    public void setEmailAndUniversity(String email, University university) {
+        this.email = email;
+        this.university = university;
+    }
 }

--- a/backend/src/main/java/com/hjjang/backend/global/config/ApplicationStartupTask.java
+++ b/backend/src/main/java/com/hjjang/backend/global/config/ApplicationStartupTask.java
@@ -15,10 +15,10 @@ public class ApplicationStartupTask implements ApplicationListener<ApplicationRe
 	private final UniversityRepository universityRepository;
 	@Override
 	public void onApplicationEvent(ApplicationReadyEvent event) {
-		if (!universityRepository.existsById(1L)){
+		if (!universityRepository.existsByName("empty")){
 			universityRepository.save(new University("empty", "empty"));
 		}
-		if (!universityRepository.existsById(2L)){
+		if (!universityRepository.existsByName("tukorea")){
 			universityRepository.save(new University("tukorea", "tukorea.ac.kr"));
 		}
 	}

--- a/backend/src/main/java/com/hjjang/backend/global/config/ApplicationStartupTask.java
+++ b/backend/src/main/java/com/hjjang/backend/global/config/ApplicationStartupTask.java
@@ -18,5 +18,8 @@ public class ApplicationStartupTask implements ApplicationListener<ApplicationRe
 		if (!universityRepository.existsById(1L)){
 			universityRepository.save(new University("empty", "empty"));
 		}
+		if (!universityRepository.existsById(2L)){
+			universityRepository.save(new University("tukorea", "tukorea.ac.kr"));
+		}
 	}
 }

--- a/backend/src/main/java/com/hjjang/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/hjjang/backend/global/config/SwaggerConfig.java
@@ -1,15 +1,25 @@
 package com.hjjang.backend.global.config;
 
-import io.swagger.v3.oas.models.ExternalDocumentation;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.info.License;
+import java.util.Arrays;
+
 import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
 @Configuration
 public class SwaggerConfig {
+    SecurityScheme securityScheme = new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+        .in(SecurityScheme.In.HEADER).name("Authorization");
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList("Bearer Token");
 
     @Bean
     public GroupedOpenApi categoryApi() {
@@ -30,13 +40,15 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI bauctionOpenAPI() {
         return new OpenAPI()
-                .info(new Info().title("bauction API")
-                        .description("중고거래 서비스 bauction의 API 입니다.")
-                        .version("v0.0.1")
-                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
-                .externalDocs(new ExternalDocumentation()
-                        .description("github link")
-                        .url("https://github.com/h-jjang/bauction"));
+            .info(new Info().title("bauction API")
+                    .description("중고거래 서비스 bauction의 API 입니다.")
+                    .version("v0.0.1")
+                    .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+            .externalDocs(new ExternalDocumentation()
+                    .description("github link")
+                    .url("https://github.com/h-jjang/bauction"))
+            .components(new Components().addSecuritySchemes("Bearer Token", securityScheme))
+            .security(Arrays.asList(securityRequirement));
     }
 
 }

--- a/backend/src/main/java/com/hjjang/backend/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/com/hjjang/backend/global/config/security/SecurityConfig.java
@@ -1,16 +1,9 @@
 package com.hjjang.backend.global.config.security;
 
-import com.hjjang.backend.domain.user.repository.UserRefreshTokenRepository;
-import com.hjjang.backend.global.config.security.properties.AuthProperties;
-import com.hjjang.backend.global.security.exception.RestAuthenticationEntryPoint;
-import com.hjjang.backend.global.security.filter.TokenAuthenticationFilter;
-import com.hjjang.backend.global.security.handler.OAuth2AuthenticationFailureHandler;
-import com.hjjang.backend.global.security.handler.OAuth2AuthenticationSuccessHandler;
-import com.hjjang.backend.global.security.handler.TokenAccessDeniedHandler;
-import com.hjjang.backend.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
-import com.hjjang.backend.global.security.service.CustomOAuth2UserService;
-import com.hjjang.backend.global.security.token.AuthTokenProvider;
-import lombok.RequiredArgsConstructor;
+import static com.hjjang.backend.domain.user.entity.RoleType.*;
+
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -26,9 +19,18 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
+import com.hjjang.backend.domain.user.repository.UserRefreshTokenRepository;
+import com.hjjang.backend.global.config.security.properties.AuthProperties;
+import com.hjjang.backend.global.security.exception.RestAuthenticationEntryPoint;
+import com.hjjang.backend.global.security.filter.TokenAuthenticationFilter;
+import com.hjjang.backend.global.security.handler.OAuth2AuthenticationFailureHandler;
+import com.hjjang.backend.global.security.handler.OAuth2AuthenticationSuccessHandler;
+import com.hjjang.backend.global.security.handler.TokenAccessDeniedHandler;
+import com.hjjang.backend.global.security.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
+import com.hjjang.backend.global.security.service.CustomOAuth2UserService;
+import com.hjjang.backend.global.security.token.AuthTokenProvider;
 
-import static com.hjjang.backend.domain.user.entity.RoleType.USER;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -80,6 +82,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() //cors를 검증 하는 option 함수의 경우 별도의 filter 없이 허용
 //            .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
             .antMatchers("/api/v1/users/**").hasAnyAuthority(USER.getCode())
+            .antMatchers("/api/mail/**").hasAnyAuthority(USER.getCode())
             .anyRequest().permitAll();
 
         http


### PR DESCRIPTION
---
name: Pull Request
about: pr 설명
title: "[PR]"
labels: ""
assignees: ''

---


## 추가한 기능 설명
- 서버 실행시 DB university 테이블에 "tukorea" 레코드 자동 생성합니다.
- 메일 api 사용시 인증 필터를 거치도록 SecurityConfig에 `api/mail/**`을 추가하였습니다.
- 메일이 인증되면 로그인된 유저의 메일과 대학 정보를 인증된 메일과 대학으로 변경되도록 하였습니다.
- swagger 
  - 발급된 토큰을 헤더에 담을 수 있도록 Authorize 비튼 추가하였습니다.
<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가? <br>
- [ ] 그외의 [pr 규칙](https://github.com/h-jjang/bauction/wiki/%5BProject-Rules%5D#pr-%EA%B7%9C%EC%B9%99)을 잘 지켰는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
설명
- [ ] naver code style formatting(단축키)을 했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?